### PR TITLE
Move declaration of Axis{:time} into core module

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -55,39 +55,28 @@ spacing of 3mm, as well as the location of the center of each voxel.
 
 (NOTE: portions of this don't work yet, but it illustrates what I'm aiming for.)
 
-You can declare that an axis corresponds to time like this:
+Any array possessing an axis `Axis{:time}` will be recognized as
+having a temporal dimension.  Given an array `A`,
 
 ```@example 2
-using ImagesAxes, SimpleTraits
-@traitimpl TimeAxis{Axis{:time}}
-```
-
-Henceforth any array possessing an axis `Axis{:time}` will be
-recognized as having a temporal dimension. (You could alternatively
-have chosen `Axis{:t}` or `Axis{:scantime}` or any other name.) Note
-this declaration affects all arrays throughout your entire session.
-Moreover, it should be made before calling any functions on
-array-types that possess such axes; a convenient place to do this is
-right after you say `using ImagesAxes` in your top-level script.
-
-Given an array `A`, you can retrieve its temporal axis with
-
-```@example 2
-using Unitful
+using ImagesAxes, Unitful
 img = AxisArray(reshape(1:9*300, (3,3,300)),
                 Axis{:x}(1:3),
                 Axis{:y}(1:3),
                 Axis{:time}(1s/30:1s/30:10s))
+```
+
+you can retrieve its temporal axis with
+
+```@example 2
 ax = timeaxis(img)
 ```
 
 and index it like
 
 ```@example 2
-# img[ax[3]]
+# img[ax(3)]
 ```
-
-Note that this requires that you've attached unique physical units to the time dimension.  Multiple time axes with different names in the same array are not supported.
 
 You can also specialize methods like this:
 
@@ -115,4 +104,20 @@ using ImagesAxes, SimpleTraits
 end
 ```
 
-and it will return the mean intensity at each timeslice, when appropriate.
+and, when appropriate, it will return the mean intensity at each timeslice.
+
+### Custom temporal axes
+
+Using `SimpleTraits`'s `@traitimpl`, you can add `Axis{:t}` or
+`Axis{:scantime}` or any other name to the list of axes that have a
+temporal dimension:
+
+```@example
+using ImagesAxes, SimpleTraits
+@traitimpl TimeAxis{Axis{:t}}
+```
+
+Note this declaration affects all arrays throughout your entire
+session.  Moreover, it should be made before calling any functions on
+array-types that possess such axes; a convenient place to do this is
+right after you say `using ImagesAxes` in your top-level script.

--- a/src/ImagesAxes.jl
+++ b/src/ImagesAxes.jl
@@ -10,7 +10,7 @@ using Reexport, Colors, SimpleTraits
 
 function Base.convert{C<:Colorant,n}(::Type{Array{C,n}},
                                      img::AxisArray{C,n})
-    copy!(Array{ccolor(Cdest, Csrc)}(size(img)), img)
+    copy!(Array{C}(size(img)), img)
 end
 function Base.convert{Cdest<:Colorant,n,Csrc<:Colorant}(::Type{Array{Cdest,n}},
                                                         img::AxisArray{Csrc,n})

--- a/src/ImagesAxes.jl
+++ b/src/ImagesAxes.jl
@@ -33,8 +33,12 @@ correspond to time:
 
     @traitimpl TimeAxis{Axis{:time}}
 
+This definition has already been made in ImagesAxes, but you can add
+new names as well.
 """
 @traitdef TimeAxis{X}
+
+@traitimpl TimeAxis{Axis{:time}}
 
 # Note: any axis not marked as a TimeAxis is assumed to correspond to
 # space. It might be useful to allow users to add other possibilities,
@@ -115,7 +119,7 @@ ImagesCore.timedim{T,N}(img::AxisArray{T,N}) = _timedim(filter_time_axis(axes(im
 _timedim(dim::Tuple{Int}) = dim[1]
 _timedim(::Tuple{}) = 0
 
-nimages(img::AxisArray) = _nimages(timeaxis(img))
+ImagesCore.nimages(img::AxisArray) = _nimages(timeaxis(img))
 _nimages(::Void) = 1
 _nimages(ax::Axis) = length(ax)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,6 @@ using ImagesAxes, Base.Test
 
 using SimpleTraits, Unitful
 
-@traitimpl TimeAxis{Axis{:time}}
-
 @traitfn has_time_axis{AA<:AxisArray;  HasTimeAxis{AA}}(::AA) = true
 @traitfn has_time_axis{AA<:AxisArray; !HasTimeAxis{AA}}(::AA) = false
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using ImagesAxes, Base.Test
+using Colors, ImagesAxes, Base.Test
 
 @test isempty(detect_ambiguities(ImagesAxes,ImagesCore,Base,Core))
 
@@ -71,6 +71,18 @@ end
     @test @inferred(indices_spatial(A)) === (Base.OneTo(3),)
     @test_throws ErrorException assert_timedim_last(A)
     @test map(istimeaxis, axes(A)) == (true,false)
+end
+
+# Possibly-ambiguous functions
+@testset "ambig" begin
+    A = AxisArray(rand(RGB{U8},3,5), :x, :y)
+    @test isa(convert(Array{RGB{U8},2}, A), Array{RGB{U8},2})
+    @test isa(convert(Array{Gray{U8},2}, A), Array{Gray{U8},2})
+end
+
+@testset "internal" begin
+    A = AxisArray(rand(RGB{U8},3,5), :x, :y)
+    @test ImagesAxes.axtype(A) == Tuple{Axis{:x,UnitRange{Int}}, Axis{:y,UnitRange{Int}}}
 end
 
 nothing


### PR DESCRIPTION
This reduces flexibility a bit but increases usability considerably.
