### PR TITLE
Support nesting for `timeaxis` over MappedArrays

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,7 @@
 julia 0.5
-ImageCore
+ImageCore 0.2
 AxisArrays
+MappedArrays
 SimpleTraits
 Reexport
 Colors

--- a/src/ImageAxes.jl
+++ b/src/ImageAxes.jl
@@ -3,7 +3,7 @@ __precompile__()
 module ImageAxes
 
 using Base: @pure, tail
-using Reexport, Colors, SimpleTraits
+using Reexport, Colors, SimpleTraits, MappedArrays
 
 @reexport using AxisArrays
 @reexport using ImageCore
@@ -38,6 +38,7 @@ new names as well.
 Return the time axis, if present, of the array `A`, and `nothing` otherwise.
 """
 @inline timeaxis(A::AxisArray) = _timeaxis(A.axes...)
+timeaxis(A::AbstractMappedArray) = timeaxis(parent(A))
 @traitfn _timeaxis{Ax<:Axis; !TimeAxis{Ax}}(ax::Ax, axes...) = _timeaxis(axes...)
 @traitfn _timeaxis{Ax<:Axis;  TimeAxis{Ax}}(ax::Ax, axes...) = ax
 _timeaxis() = nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Colors, FixedPointNumbers, ImageAxes, Base.Test
+using Colors, FixedPointNumbers, ImageAxes, MappedArrays, Base.Test
 
 if VERSION < v"0.6.0-dev"
     ambs = detect_ambiguities(ImageAxes,ImageCore,Base,Core)
@@ -104,6 +104,44 @@ end
     p = permuteddimsview(cv, (2,3,1))
     @test axes(p) == (Axis{:y}(1:4), Axis{:x}(1:5), Axis{:color}(1:3))
     @test colordim(p) == 3
+end
+
+@testset "nested" begin
+    A = AxisArray(rand(RGB{N0f8}, 4, 5), (:y, :x), (2, 1))
+    P = permuteddimsview(A, (2, 1))
+    @test @inferred(pixelspacing(P)) == (1, 2)
+    M = mappedarray(identity, A)
+    @test @inferred(pixelspacing(M)) == (2, 1)
+    const s = u"s"
+    const μm = u"μm"
+    tax = Axis{:time}(range(0.0s, 0.1s, 11))
+    A = AxisArray(rand(N0f16, 4, 5, 11), (:y, :x, :time), (2μm, 1μm, 0.1s))
+    P = permuteddimsview(A, (3, 1, 2))
+    M = mappedarray(identity, A)
+    @test @inferred(pixelspacing(P)) == @inferred(pixelspacing(M)) == (2μm, 1μm)
+    @test @inferred(timeaxis(P)) == @inferred(timeaxis(M)) == tax
+    @test has_time_axis(P)
+    @test coords_spatial(P) == (2, 3)
+    @test coords_spatial(M) == (1, 2)
+    @test spatialorder(P) == spatialorder(M) == (:y, :x)
+    @test @inferred(size_spatial(P)) == @inferred(size_spatial(M)) == (4, 5)
+    @test_throws ErrorException assert_timedim_last(P)
+    assert_timedim_last(M)
+    A = AxisArray(rand(N0f16, 11, 5, 4), (:time, :x, :y), (0.1s, 1μm, 2μm))
+    P = permuteddimsview(A, (3, 2, 1))
+    M = mappedarray(identity, A)
+    @test @inferred(pixelspacing(P)) == (2μm, 1μm)
+    @test @inferred(pixelspacing(M)) == (1μm, 2μm)
+    @test @inferred(timeaxis(P)) == @inferred(timeaxis(M)) == tax
+    @test has_time_axis(P)
+    @test coords_spatial(P) == (1, 2)
+    @test coords_spatial(M) == (2, 3)
+    @test spatialorder(P) == (:y, :x)
+    @test spatialorder(M) == (:x, :y)
+    @test @inferred(size_spatial(P)) == (4, 5)
+    @test @inferred(size_spatial(M)) == (5, 4)
+    assert_timedim_last(P)
+    @test_throws ErrorException assert_timedim_last(M)
 end
 
 # Possibly-ambiguous functions


### PR DESCRIPTION
Plus add tests of nesting behavior. This is the follow-up to https://github.com/JuliaImages/ImageCore.jl/pull/30, and tests that the nesting behavior produces more obviously-useful results.