### PR TITLE
Implement StreamingTimeArray and ReadOnlyArray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - osx
 julia:
   - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ environment:
   matrix:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,25 @@
-using Colors, FixedPointNumbers, ImageAxes, MappedArrays, Base.Test
+using Colors, FixedPointNumbers, MappedArrays, Base.Test, ImageCore, AxisArrays
+using Compat
+
+ambs = detect_ambiguities(ImageCore,AxisArrays,Base,Core)
+using ImageAxes
+ambs = setdiff(detect_ambiguities(ImageAxes,ImageCore,AxisArrays,Base,Core), ambs)
+if !isempty(ambs)
+    println("Ambiguities:")
+    for a in ambs
+        println(a)
+    end
+end
+@test isempty(ambs)
 
 if VERSION < v"0.6.0-dev"
-    ambs = detect_ambiguities(ImageAxes,ImageCore,Base,Core)
-    if !isempty(ambs)
-        println("Ambiguities:")
-        for a in ambs
-            println(a)
-        end
+    macro inferred6(arg)
+        arg
     end
-    @test isempty(ambs)
+else
+    macro inferred6(arg)
+        :(Base.Test.@inferred($(esc(arg))))
+    end
 end
 
 using SimpleTraits, Unitful
@@ -158,14 +169,33 @@ end
     @test ImageAxes.axtype(A) == Tuple{Axis{:x,Base.OneTo{Int}}, Axis{:y,Base.OneTo{Int}}}
 end
 
+# For testing streaming with a non-AxisArray parent
+module TestStreaming
+using AxisArrays, ImageAxes
+
+immutable AVIStream
+    dims::NTuple{3,Int}
+end
+Base.ndims(::AVIStream) = 3
+Base.size(A::AVIStream) = A.dims
+AxisArrays.axisnames{AS<:AVIStream}(::Type{AS}) = (:y, :x, :time)
+AxisArrays.axes(A::AVIStream) = (Axis{:y}(Base.OneTo(A.dims[1])),
+                                 Axis{:x}(Base.OneTo(A.dims[2])),
+                                 Axis{:time}(Base.OneTo(A.dims[3])))
+(::Type{ImageAxes.StreamIndexStyle})(::Type{AVIStream}, ::Type{typeof(read!)}) =
+    IndexIncremental()
+
+end
+
 @testset "streaming" begin
     P = AxisArray([0 0 0 0;
                    1 2 3 4;
                    0 0 0 0], :x, :time)
     f!(dest, a) = (dest[1] = dest[3] = -0.2*a[2]; dest[2] = 0.6*a[2]; dest)
-    S = @inferred(StreamingArray{Float64}(f!, P, Axis{:time}()))
+    S = @inferred6(StreamingContainer{Float64}(f!, P, Axis{:time}()))
     @test @inferred(indices(S)) === (Base.OneTo(3), Base.OneTo(4))
     @test @inferred(size(S)) == (3,4)
+    @test @inferred(length(S)) == 12
     @test @inferred(axisnames(S)) == (:x, :time)
     @test @inferred(axisvalues(S)) === (Base.OneTo(3), Base.OneTo(4))
     @test axisdim(S, Axis{:x}) == axisdim(S, Axis{:x}(1:2)) == axisdim(S, Axis{:x,UnitRange{Int}}) == 1
@@ -191,8 +221,15 @@ end
     @test @inferred(getindex!(buf, S, :, 2)) == [-0.2,0.6,-0.2]*2
     @test StreamIndexStyle(S) === IndexAny()
     @test StreamIndexStyle(zeros(2,2)) === IndexAny()
+    # Non-AbstractArray parent
+    @test_throws DimensionMismatch StreamingContainer{UInt8}(read!, TestStreaming.AVIStream((1080,1920,10000)), Axis{:foo}())
+    V = StreamingContainer{UInt8}(read!, TestStreaming.AVIStream((1080,1920,10000)), Axis{:time}())
+    @test size(V) == (1080,1920,10000)
+    @test axisnames(V) == (:y, :x, :time)
+    @test StreamIndexStyle(V) === IndexIncremental()
     # internal
     @test ImageAxes.streamingaxisnames(S) == (:time,)
+    @test ImageAxes.filter_streamed((1,2), S) == (2,)
 end
 
 info("Beginning of tests with deprecation warnings")


### PR DESCRIPTION
Note that this PR is not complete because it's lacking tests; I'm interested in feedback about whether this is useful.

This adds a new ~~AbstractArray~~ type,  `StreamingTimeArray`, to represent array types possessing a time axis but for which switching time "slices" may have restrictions or may not be cheap.

At the moment I envision two uses for this type:
- [VideoIO](https://github.com/kmsquire/VideoIO.jl) (ping @kmsquire), where decompressing an AVI is done on a frame-by-frame basis; at the moment we don't have full "random access" to the stream, but even if we do some day, switching time slices is going to be expensive.
- A "demo" package [SpatiallyFilteredViews](https://github.com/timholy/SpatiallyFilteredViews.jl), which allows one to apply spatial filtering "on the fly" to a large movie. This package is incomplete, but it seems useful enough in my own work that I suspect I will finish it. If it's of general use I could move it to JuliaImages.

One specific thing I'd like feedback on is the degree to which these (and especially the latter) are an abuse of the "view" concept. It is a view in the sense that it's lazy and doesn't allocate a tremendous amount of memory. However, it doesn't follow the "changes in the view also generate changes in the parent." For that reason I also added a `ReadOnlyArray` wrapper, so that any attempt to set pixel values in the view will result in an error (of course users can still copy the data to any `Array` and then tweak to their heart's content).
