### PR TITLE
update to Julia v0.7, prepare for 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,31 @@
-# Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
 os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
+  - 1.0
   - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false
-# uncomment the following lines to override the default test script
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.add("Unitful")'   # we need this for the docs as well as the tests
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("ImageAxes"); Pkg.test("ImageAxes"; coverage=true)'
+  - julia -e 'import Pkg; Pkg.add("Unitful")'   # we need this for the docs as well as the tests
+  - julia -e 'import Pkg; Pkg.clone(pwd()); Pkg.build("ImageAxes"); Pkg.test("ImageAxes"; coverage=true)'
+# FIXME: enable deploy for merges into master
+# jobs:
+#   include:
+#     - stage: deploy
+#       julia: 0.7
+#       os: linux
+#       script:
+#         - julia -e 'import Pkg; Pkg.clone(pwd()); Pkg.build("ImageAxes")'
+#         - julia -e 'import Pkg; Pkg.add("Documenter")'
+#         - julia -e 'import ImageAxes; include("docs/make.jl")'
+
 after_success:
   # push coverage results to Codecov
   - julia -e 'cd(Pkg.dir("ImageAxes")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
-  # update the documentation
-  - julia -e 'Pkg.add("Documenter")'
-  - julia -e 'cd(Pkg.dir("ImageAxes")); ENV["DOCUMENTER_DEBUG"] = "true"; include(joinpath("docs", "make.jl"))'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7
 ImageCore 0.2
 AxisArrays
 MappedArrays

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,18 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1.0
+  - julia_version: latest
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+## uncomment the following lines to allow failures on nightly julia
+## (tests will run but not make your overall status red)
+matrix:
+  allow_failures:
+  - julia_version: latest
 
 branches:
   only:
@@ -17,19 +26,12 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"ImageAxes\"); Pkg.build(\"ImageAxes\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"ImageAxes\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -91,8 +91,8 @@ arrays that have a timeaxis. A more complex example is
 
 ```julia
 using ImageAxes, SimpleTraits
-@traitfn meanintensity{AA<:AxisArray; !HasTimeAxis{AA}}(img::AA) = mean(img)
-@traitfn function meanintensity{AA<:AxisArray; HasTimeAxis{AA}}(img::AA)
+@traitfn meanintensity(img::AA) where {AA<:AxisArray; !HasTimeAxis{AA}} = mean(img)
+@traitfn function meanintensity(img::AA) where {AA<:AxisArray; HasTimeAxis{AA}}
     ax = timeaxis(img)
     n = length(x)
     intensity = zeros(eltype(img), n)

--- a/src/ImageAxes.jl
+++ b/src/ImageAxes.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module ImageAxes
 
 using Base: @pure, tail
@@ -8,6 +6,9 @@ using Compat
 
 @reexport using AxisArrays
 @reexport using ImageCore
+import AxisArrays
+using AxisArrays: AxisArray, Axis, axisnames, axisvalues, axisdim, atindex, atvalue, collapse
+export AxisArray, Axis, axisnames, axisvalues, axisdim, atindex, atvalue, collapse
 
 export # types
     HasTimeAxis,
@@ -53,8 +54,8 @@ Return the time axis, if present, of the array `A`, and `nothing` otherwise.
 @inline timeaxis(A::AxisArray) = _timeaxis(A.axes...)
 timeaxis(A::AbstractArray) = nothing
 timeaxis(A::AbstractMappedArray) = timeaxis(parent(A))
-@traitfn _timeaxis{Ax<:Axis; !TimeAxis{Ax}}(ax::Ax, axes...) = _timeaxis(axes...)
-@traitfn _timeaxis{Ax<:Axis;  TimeAxis{Ax}}(ax::Ax, axes...) = ax
+@traitfn _timeaxis(ax::Ax, axes...) where {Ax<:Axis; !TimeAxis{Ax}} = _timeaxis(axes...)
+@traitfn _timeaxis(ax::Ax, axes...) where {Ax<:Axis;  TimeAxis{Ax}} = ax
 _timeaxis() = nothing
 
 
@@ -64,8 +65,8 @@ _timeaxis() = nothing
 Test whether the axis `ax` corresponds to time.
 """
 istimeaxis(ax::Axis) = istimeaxis(typeof(ax))
-@traitfn istimeaxis{Ax<:Axis; !TimeAxis{Ax}}(::Type{Ax}) = false
-@traitfn istimeaxis{Ax<:Axis;  TimeAxis{Ax}}(::Type{Ax}) = true
+@traitfn istimeaxis(::Type{Ax}) where {Ax<:Axis; !TimeAxis{Ax}} = false
+@traitfn istimeaxis(::Type{Ax}) where {Ax<:Axis;  TimeAxis{Ax}} = true
 
 @traitdef HasTimeAxis{X}
 """
@@ -99,10 +100,10 @@ julia> got_time(A)
 """
 HasTimeAxis
 
-axtype{T,N,D,Ax}(::Type{AxisArray{T,N,D,Ax}}) = Ax
+axtype(::Type{AxisArray{T,N,D,Ax}}) where {T,N,D,Ax} = Ax
 axtype(A::AxisArray) = axtype(typeof(A))
 
-Base.@pure function SimpleTraits.trait{AA<:AxisArray}(t::Type{HasTimeAxis{AA}})
+Base.@pure function SimpleTraits.trait(t::Type{HasTimeAxis{AA}}) where AA<:AxisArray
     axscan = map(S->istimeaxis(S), axtype(AA).parameters)
     any(axscan) ? HasTimeAxis{AA} : Not{HasTimeAxis{AA}}
 end
@@ -117,9 +118,9 @@ function ImageCore.channelview(A::AxisArray)
     _channelview(A, Ac)
 end
 # without extra dimension:
-_channelview{C,T,N}(A::AxisArray{C,N}, Ac::AbstractArray{T,N}) = AxisArray(Ac, AxisArrays.axes(A)...)
+_channelview(A::AxisArray{C,N}, Ac::AbstractArray{T,N}) where {C,T,N} = AxisArray(Ac, AxisArrays.axes(A)...)
 # with extra dimension: (bug: the type parameters shouldn't be necessary, but julia 0.5 dispatches incorrectly without them)
-_channelview{C,T,M,N}(A::AxisArray{C,M}, Ac::AbstractArray{T,N}) = AxisArray(Ac, Axis{:color}(indices(Ac,1)), AxisArrays.axes(A)...)
+_channelview(A::AxisArray{C,M}, Ac::AbstractArray{T,N}) where {C,T,M,N} = AxisArray(Ac, Axis{:color}(indices(Ac,1)), AxisArrays.axes(A)...)
 
 
 ### Image properties based on traits ###
@@ -133,19 +134,19 @@ using an axis for this purpose.
 Note: if you want to recover information about the time axis, it is
 generally better to use `timeaxis`.
 """
-timedim{T,N}(img::AxisArray{T,N}) = _timedim(filter_time_axis(AxisArrays.axes(img), ntuple(identity, Val{N})))
+timedim(img::AxisArray{T,N}) where {T,N} = _timedim(filter_time_axis(AxisArrays.axes(img), ntuple(identity, Val{N})))
 _timedim(dim::Tuple{Int}) = dim[1]
 _timedim(::Tuple{}) = 0
 
 ImageCore.nimages(img::AxisArray) = _nimages(timeaxis(img))
-_nimages(::Void) = 1
+_nimages(::Nothing) = 1
 _nimages(ax::Axis) = length(ax)
 
 function colordim(img::AxisArray)
     d = _colordim(1, AxisArrays.axes(img))
     d > ndims(img) ? 0 : d
 end
-_colordim{Ax<:Axis{:color}}(d, ax::Tuple{Ax,Vararg{Any}}) = d
+_colordim(d, ax::Tuple{Ax,Vararg{Any}}) where {Ax<:Axis{:color}} = d
 _colordim(d, ax::Tuple{Any,Vararg{Any}}) = _colordim(d+1, tail(ax))
 _colordim(d, ax::Tuple{}) = d+1
 
@@ -153,7 +154,7 @@ ImageCore.pixelspacing(img::AxisArray) = map(step, filter_space_axes(AxisArrays.
 
 ImageCore.spacedirections(img::AxisArray) = ImageCore._spacedirections(pixelspacing(img))
 
-ImageCore.coords_spatial{T,N}(img::AxisArray{T,N}) = filter_space_axes(AxisArrays.axes(img), ntuple(identity, Val{N}))
+ImageCore.coords_spatial(img::AxisArray{T,N}) where {T,N} = filter_space_axes(AxisArrays.axes(img), ntuple(identity, Val{N}))
 
 ImageCore.spatialorder(img::AxisArray) = filter_space_axes(AxisArrays.axes(img), axisnames(img))
 
@@ -165,26 +166,26 @@ data(img::AxisArray) = img.data
 ### Utilities for writing "simple algorithms" safely ###
 
 # Check that the time dimension, if present, is last
-@traitfn function ImageCore.assert_timedim_last{AA<:AxisArray; HasTimeAxis{AA}}(img::AA)
+@traitfn function ImageCore.assert_timedim_last(img::AA) where {AA<:AxisArray; HasTimeAxis{AA}}
     ax = AxisArrays.axes(img)[end]
     istimeaxis(ax) || error("time dimension is not last")
     nothing
 end
-@traitfn ImageCore.assert_timedim_last{AA<:AxisArray; !HasTimeAxis{AA}}(img::AA) = nothing
+@traitfn ImageCore.assert_timedim_last(img::AA) where {AA<:AxisArray; !HasTimeAxis{AA}} = nothing
 
 ### Convert ###
-function Base.convert{C<:Colorant,n}(::Type{Array{C,n}},
-                                     img::AxisArray{C,n})
+function Base.convert(::Type{Array{C,n}},
+                      img::AxisArray{C,n}) where {C<:Colorant,n}
     copy!(Array{C}(size(img)), img)
 end
-function Base.convert{Cdest<:Colorant,n,Csrc<:Colorant}(::Type{Array{Cdest,n}},
-                                                        img::AxisArray{Csrc,n})
+function Base.convert(::Type{Array{Cdest,n}},
+                      img::AxisArray{Csrc,n}) where {Cdest<:Colorant,n,Csrc<:Colorant}
     copy!(Array{ccolor(Cdest, Csrc)}(size(img)), img)
 end
 
 ### StreamingContainer ###
 
-checknames{P}(axnames, ::Type{P}) = checknames(axnames, axisnames(P))
+checknames(axnames, ::Type{P}) where {P} = checknames(axnames, axisnames(P))
 @noinline function checknames(axnames, parentnames::Tuple{Symbol,Vararg{Symbol}})
     mapreduce(x->in(x, parentnames), &, axnames) || throw(DimensionMismatch("names $axnames are not included among $parentnames"))
     nothing
@@ -224,11 +225,11 @@ have dimensionality `ndims(parent)-length(streamingaxes)`.
 
 Optionally, define [`StreamIndexStyle(typeof(parent),typeof(f!))`](@ref).
 """
-immutable StreamingContainer{T,N,streamingaxisnames,P,GetIndex}
+struct StreamingContainer{T,N,streamingaxisnames,P,GetIndex}
     getindex!::GetIndex
     parent::P
 end
-function (::Type{StreamingContainer{T}}){T}(f!::Function, parent, axs::Axis...)
+function StreamingContainer{T}(f!::Function, parent, axs::Axis...) where T
     N = ndims(parent)
     axnames = axisnames(axs...)
     checknames(axnames, typeof(parent))
@@ -244,7 +245,7 @@ Base.size(S::StreamingContainer, d)    = size(S.parent, d)
 AxisArrays.axes(S::StreamingContainer) = AxisArrays.axes(parent(S))
 AxisArrays.axisnames(S::StreamingContainer)  = axisnames(AxisArrays.axes(S)...)
 AxisArrays.axisvalues(S::StreamingContainer) = axisvalues(AxisArrays.axes(S)...)
-function AxisArrays.axisdim{name}(S::StreamingContainer, ::Type{Axis{name}})
+function AxisArrays.axisdim(S::StreamingContainer, ::Type{Axis{name}}) where name
     isa(name, Int) && return name <= ndims(S) ? name : error("axis $name greater than array dimensionality $(ndims(S))")
     names = axisnames(S)
     idx = findfirst(names, name)
@@ -252,10 +253,10 @@ function AxisArrays.axisdim{name}(S::StreamingContainer, ::Type{Axis{name}})
     idx
 end
 AxisArrays.axisdim(S::StreamingContainer, ax::Axis) = axisdim(S, typeof(ax))
-AxisArrays.axisdim{name,T}(S::StreamingContainer, ::Type{Axis{name,T}}) = axisdim(S, Axis{name})
+AxisArrays.axisdim(S::StreamingContainer, ::Type{Axis{name,T}}) where {name,T} = axisdim(S, Axis{name})
 
 ImageCore.nimages(S::StreamingContainer) = _nimages(timeaxis(S))
-ImageCore.coords_spatial{T,N}(S::StreamingContainer{T,N}) =
+ImageCore.coords_spatial(S::StreamingContainer{T,N}) where {T,N} =
     filter_space_axes(AxisArrays.axes(S), ntuple(identity, Val{N}))
 ImageCore.spatialorder(S::StreamingContainer) = filter_space_axes(AxisArrays.axes(S), axisnames(S))
 ImageCore.size_spatial(img::StreamingContainer)    = filter_space_axes(AxisArrays.axes(img), size(img))
@@ -265,13 +266,13 @@ function ImageCore.assert_timedim_last(S::StreamingContainer)
     nothing
 end
 
-Base.eltype{T,N,names,P,GetIndex}(::Type{StreamingContainer{T,N,names,P,GetIndex}}) = T
+Base.eltype(::Type{StreamingContainer{T,N,names,P,GetIndex}}) where {T,N,names,P,GetIndex} = T
 Base.eltype(S::StreamingContainer) = eltype(typeof(S))
-Base.ndims{T,N,names,P,GetIndex}(::Type{StreamingContainer{T,N,names,P,GetIndex}}) = N
+Base.ndims(::Type{StreamingContainer{T,N,names,P,GetIndex}}) where {T,N,names,P,GetIndex} = N
 Base.ndims(S::StreamingContainer) = ndims(typeof(S))
 Base.length(S::StreamingContainer) = prod(size(S))
 
-streamingaxisnames{T,N,names,P,GetIndex}(::Type{StreamingContainer{T,N,names,P,GetIndex}}) =
+streamingaxisnames(::Type{StreamingContainer{T,N,names,P,GetIndex}}) where {T,N,names,P,GetIndex} =
     names
 streamingaxisnames(S::StreamingContainer) = streamingaxisnames(typeof(S))
 
@@ -294,8 +295,8 @@ end
     f!(dest, v)
 end
 
-function isstreamedaxis{name,T,N,saxnames}(ax::Axis{name},
-                                           S::StreamingContainer{T,N,saxnames})
+function isstreamedaxis(ax::Axis{name},
+                        S::StreamingContainer{T,N,saxnames}) where {name,T,N,saxnames}
     in(name, saxnames)
 end
 
@@ -308,17 +309,17 @@ filter_notstreamed(inds, S) = _filter_notstreamed(inds, AxisArrays.axes(S), S)
 filter_streamed(inds::Tuple{Axis,Vararg{Axis}}, S)    = _filter_streamed(inds, inds, S)
 filter_notstreamed(inds::Tuple{Axis,Vararg{Axis}}, S) = _filter_notstreamed(inds, inds, S)
 
-@generated function _filter_streamed{N}(a, axs::NTuple{N,Axis}, S::StreamingContainer)
+@generated function _filter_streamed(a, axs::NTuple{N,Axis}, S::StreamingContainer) where N
     inds = findin(axisnames(axs.parameters...), streamingaxisnames(S))
     Expr(:tuple, Expr[:(a[$i]) for i in inds]...)
 end
-@generated function _filter_notstreamed{N}(a, axs::NTuple{N,Axis}, S::StreamingContainer)
+@generated function _filter_notstreamed(a, axs::NTuple{N,Axis}, S::StreamingContainer) where N
     inds = findin(axisnames(axs.parameters...), streamingaxisnames(S))
     inds = setdiff(1:N, inds)
     Expr(:tuple, Expr[:(a[$i]) for i in inds]...)
 end
 
-@inline function Base.getindex{T,N}(S::StreamingContainer{T,N}, inds::Vararg{Union{Colon,Base.ViewIndex},N})
+@inline function Base.getindex(S::StreamingContainer{T,N}, inds::Vararg{Union{Colon,Base.ViewIndex},N}) where {T,N}
     tmp = similar(Array{T}, sliceindices(S))
     getindex!(tmp, S, getslicedindices(S, inds)...)
     tmp[filter_notstreamed(inds, S)...]
@@ -346,45 +347,45 @@ This should be specialized for the type rather than the instance. For
 a StreamingContainer `S`, you can define this trait via
 
 ```julia
-(::Type{StreamIndexStyle})(::Type{P}, ::typeof(f!)) = IndexIncremental()
+StreamIndexStyle(::Type{P}, ::typeof(f!)) = IndexIncremental()
 ```
 
 where `P = typeof(parent(S))`.
 """
-@compat abstract type StreamIndexStyle end
-immutable IndexAny <: StreamIndexStyle end
-immutable IndexIncremental <: StreamIndexStyle end
+abstract type StreamIndexStyle end
+struct IndexAny <: StreamIndexStyle end
+struct IndexIncremental <: StreamIndexStyle end
 
-(::Type{StreamIndexStyle}){A<:AbstractArray}(::Type{A}) = IndexAny()
-(::Type{StreamIndexStyle})(A::AbstractArray) = StreamIndexStyle(typeof(A))
+StreamIndexStyle(::Type{A}) where {A<:AbstractArray} = IndexAny()
+StreamIndexStyle(A::AbstractArray) = StreamIndexStyle(typeof(A))
 
-(::Type{StreamIndexStyle}){T,N,axnames,P,GetIndex}(::Type{StreamingContainer{T,N,axnames,P,GetIndex}}) = StreamIndexStyle(P, GetIndex)
-(::Type{StreamIndexStyle}){P,GetIndex}(::Type{P},::Type{GetIndex}) = IndexAny()
+StreamIndexStyle(::Type{StreamingContainer{T,N,axnames,P,GetIndex}}) where {T,N,axnames,P,GetIndex} = StreamIndexStyle(P, GetIndex)
+StreamIndexStyle(::Type{P},::Type{GetIndex}) where {P,GetIndex} = IndexAny()
 
-(::Type{StreamIndexStyle})(S::StreamingContainer) = StreamIndexStyle(typeof(S))
+StreamIndexStyle(S::StreamingContainer) = StreamIndexStyle(typeof(S))
 
 ### Low level utilities ###
 
-filter_space_axes{N}(axes::NTuple{N,Axis}, items::NTuple{N,Any}) =
+filter_space_axes(axes::NTuple{N,Axis}, items::NTuple{N,Any}) where {N} =
     _filter_space_axes(axes, items)
-@inline @traitfn _filter_space_axes{Ax<:Axis;  TimeAxis{Ax}}(axes::Tuple{Ax,Vararg{Any}}, items) =
+@inline @traitfn _filter_space_axes(axes::Tuple{Ax,Vararg{Any}}, items) where {Ax<:Axis;  TimeAxis{Ax}} =
     _filter_space_axes(tail(axes), tail(items))
-@inline @traitfn _filter_space_axes{Ax<:Axis; !TimeAxis{Ax}}(axes::Tuple{Ax,Vararg{Any}}, items) =
+@inline @traitfn _filter_space_axes(axes::Tuple{Ax,Vararg{Any}}, items) where {Ax<:Axis; !TimeAxis{Ax}} =
     (items[1], _filter_space_axes(tail(axes), tail(items))...)
 _filter_space_axes(::Tuple{}, ::Tuple{}) = ()
-@inline _filter_space_axes{Ax<:Axis{:color}}(axes::Tuple{Ax,Vararg{Any}}, items) =
+@inline _filter_space_axes(axes::Tuple{Ax,Vararg{Any}}, items) where {Ax<:Axis{:color}} =
     _filter_space_axes(tail(axes), tail(items))
 
-filter_time_axis{N}(axes::NTuple{N,Axis}, items::NTuple{N}) =
+filter_time_axis(axes::NTuple{N,Axis}, items::NTuple{N}) where {N} =
     _filter_time_axis(axes, items)
-@inline @traitfn _filter_time_axis{Ax<:Axis; !TimeAxis{Ax}}(axes::Tuple{Ax,Vararg{Any}}, items) =
+@inline @traitfn _filter_time_axis(axes::Tuple{Ax,Vararg{Any}}, items) where {Ax<:Axis; !TimeAxis{Ax}} =
     _filter_time_axis(tail(axes), tail(items))
-@inline @traitfn _filter_time_axis{Ax<:Axis;  TimeAxis{Ax}}(axes::Tuple{Ax,Vararg{Any}}, items) =
+@inline @traitfn _filter_time_axis(axes::Tuple{Ax,Vararg{Any}}, items) where {Ax<:Axis;  TimeAxis{Ax}} =
     (items[1], _filter_time_axis(tail(axes), tail(items))...)
 _filter_time_axis(::Tuple{}, ::Tuple{}) = ()
 
 # summary: print color types & fixed-point types compactly
-function AxisArrays._summary{T<:Union{Fractional,Colorant},N}(io, A::AxisArray{T,N})
+function AxisArrays._summary(io, A::AxisArray{T,N}) where {T<:Union{Fractional,Colorant},N}
     print(io, "$N-dimensional AxisArray{")
     if T<:Colorant
         ColorTypes.colorant_string_with_eltype(io, T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Colors, FixedPointNumbers, MappedArrays, Base.Test, ImageCore, AxisArrays
+using Colors, FixedPointNumbers, MappedArrays, Test, ImageCore, AxisArrays
 using Compat
 
 ambs = detect_ambiguities(ImageCore,AxisArrays,Base,Core)
@@ -12,20 +12,14 @@ if !isempty(ambs)
 end
 @test isempty(ambs)
 
-if VERSION < v"0.6.0-rc2"
-    macro inferred6(arg)
-        arg
-    end
-else
-    macro inferred6(arg)
-        :(Base.Test.@inferred($(esc(arg))))
-    end
+macro inferred6(arg)
+    :(Base.Test.@inferred($(esc(arg))))
 end
 
 using SimpleTraits, Unitful
 
-@traitfn has_time_axis{AA<:AxisArray;  HasTimeAxis{AA}}(::AA) = true
-@traitfn has_time_axis{AA<:AxisArray; !HasTimeAxis{AA}}(::AA) = false
+@traitfn has_time_axis(::AA) where {AA<:AxisArray;  HasTimeAxis{AA}} = true
+@traitfn has_time_axis(::AA) where {AA<:AxisArray; !HasTimeAxis{AA}} = false
 
 @testset "no units, no time" begin
     A = AxisArray(reshape(1:12, 3, 4), Axis{:x}(1:3), Axis{:y}(1:4))
@@ -173,16 +167,16 @@ end
 module TestStreaming
 using AxisArrays, ImageAxes
 
-immutable AVIStream
+struct AVIStream
     dims::NTuple{3,Int}
 end
 Base.ndims(::AVIStream) = 3
 Base.size(A::AVIStream) = A.dims
-AxisArrays.axisnames{AS<:AVIStream}(::Type{AS}) = (:y, :x, :time)
+AxisArrays.axisnames(::Type{AS}) where {AS<:AVIStream} = (:y, :x, :time)
 AxisArrays.axes(A::AVIStream) = (Axis{:y}(Base.OneTo(A.dims[1])),
                                  Axis{:x}(Base.OneTo(A.dims[2])),
                                  Axis{:time}(Base.OneTo(A.dims[3])))
-(::Type{ImageAxes.StreamIndexStyle})(::Type{AVIStream}, ::Type{typeof(read!)}) =
+ImageAxes.StreamIndexStyle(::Type{AVIStream}, ::Type{typeof(read!)}) =
     IndexIncremental()
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
-using Colors, FixedPointNumbers, MappedArrays, Test, ImageCore, AxisArrays
+using Colors, FixedPointNumbers, MappedArrays, Test, ImageCore
 using Compat
+import AxisArrays
 
 ambs = detect_ambiguities(ImageCore,AxisArrays,Base,Core)
 using ImageAxes
@@ -184,9 +185,9 @@ end
     f!(dest, a) = (dest[1] = dest[3] = -0.2*a[2]; dest[2] = 0.6*a[2]; dest)
     # Next inference was special-cased for v0.6
     S = @inferred(StreamingContainer{Float64}(f!, P, Axis{:time}()))
-    @test @inferred(indices(S)) === (Base.OneTo(3), Base.OneTo(4))
+    @test @inferred(axes(S)) === (Base.OneTo(3), Base.OneTo(4))
     @test @inferred(size(S)) == (3,4)
-    @test @inferred(indices(S, 2)) === Base.OneTo(4)
+    @test @inferred(axes(S, 2)) === Base.OneTo(4)
     @test @inferred(size(S, 1)) === 3
     @test @inferred(length(S)) == 12
     @test @inferred(axisnames(S)) == (:x, :time)


### PR DESCRIPTION
This builds on @Cody-G's work to qualify `axes` calls, and attempts to get the package working on Julia v0.7.  A new version of AxisArrays will presumably be needed for this to work on v1.0.