### PR TITLE
Deprecate `data` in favor of `arraydata`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,29 +3,24 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
+  - 1.1
   - nightly
 matrix:
   allow_failures:
     - julia: nightly
 notifications:
   email: false
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'import Pkg; Pkg.add("Unitful")'   # we need this for the docs as well as the tests
-  - julia -e 'import Pkg; Pkg.clone(pwd()); Pkg.build("ImageAxes"); Pkg.test("ImageAxes"; coverage=true)'
 
 jobs:
   include:
     - stage: deploy
-      julia: 0.7
+      julia: 1.0
       os: linux
       script:
-        - julia -e 'import Pkg; Pkg.clone(pwd()); Pkg.build("ImageAxes")'
-        - julia -e 'import Pkg; Pkg.add("Documenter")'
+        - julia -e 'import Pkg; Pkg.add(["Documenter", "Unitful"])'
         - julia -e 'import ImageAxes; include("docs/make.jl")'
 
 after_success:
   # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("ImageAxes")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'import Pkg; cd(Pkg.dir("ImageAxes")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,25 @@
+name = "ImageAxes"
+uuid = "2803e5a7-5153-5ecf-9a86-9b4c37f5f5ac"
+version = "0.6.0"
+
+[deps]
+AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+MappedArrays = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
+
+[compat]
+AxisArrays = "≥ 0.3.0"
+FixedPointNumbers = "≥ 0.3.0"
+ImageCore = "≥ 0.2.0"
+julia = "≥ 1.0.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[targets]
+test = ["Unitful", "Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,0 @@
-julia 0.7
-ImageCore 0.2
-AxisArrays 0.3
-MappedArrays
-SimpleTraits
-Reexport
-Colors
-FixedPointNumbers 0.3.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1.0
-  - julia_version: latest
+  - julia_version: 1
+  - julia_version: nightly
 
 platform:
   - x86 # 32-bit
@@ -12,7 +12,7 @@ platform:
 ## (tests will run but not make your overall status red)
 matrix:
   allow_failures:
-  - julia_version: latest
+  - julia_version: nightly
 
 branches:
   only:

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,14 +1,11 @@
-using Documenter, ImageAxes
+using Documenter, ImageAxes, SimpleTraits
 
 makedocs(modules  = [ImageAxes],
-         format   = Documenter.Formats.HTML,
+         format   = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),
          sitename = "ImageAxes",
-         pages    = ["index.md"])
+         linkcheck = !("skiplinks" in ARGS),
+         pages    = ["index.md", "reference.md"])
 
 deploydocs(
            repo   = "github.com/JuliaImages/ImageAxes.jl.git",
-           julia  = "0.5",
-           target = "build",
-           deps   = nothing,
-           make   = nothing
            )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,7 +10,7 @@ axes and one temporal axis; this fact may be relevant for how one
 performs image processing.
 
 This package combines features from
-[AxisArrays](https://github.com/mbauman/AxisArrays.jl) and
+[AxisArrays](https://github.com/JuliaArrays/AxisArrays.jl) and
 [SimpleTraits](https://github.com/mauro3/SimpleTraits.jl) to provide a
 convenient representation and programming paradigm for dealing with
 such images.
@@ -32,7 +32,7 @@ using ImageAxes
 img = AxisArray(reshape(1:192, (8,8,3)), :x, :y, :z)
 ```
 
-As described in more detail in the [AxisArrays documentation](https://github.com/mbauman/AxisArrays.jl), you can now take slices like this:
+As described in more detail in the [AxisArrays documentation](https://github.com/JuliaArrays/AxisArrays.jl), you can now take slices like this:
 
 ```@example 1
 sl = img[Axis{:z}(2)]
@@ -82,8 +82,8 @@ You can also specialize methods like this:
 
 ```@example
 using ImageAxes, SimpleTraits
-@traitfn nimages{AA<:AxisArray;  HasTimeAxis{AA}}(img::AA) = length(timeaxis(img))
-@traitfn nimages{AA<:AxisArray; !HasTimeAxis{AA}}(img::AA) = 1
+@traitfn nimages(img::AA) where {AA<:AxisArray;  HasTimeAxis{AA}} = length(timeaxis(img))
+@traitfn nimages(img::AA) where {AA<:AxisArray; !HasTimeAxis{AA}} = 1
 ```
 
 where the pre-defined `HasTimeAxis` trait will restrict that method to
@@ -121,3 +121,10 @@ Note this declaration affects all arrays throughout your entire
 session.  Moreover, it should be made before calling any functions on
 array-types that possess such axes; a convenient place to do this is
 right after you say `using ImageAxes` in your top-level script.
+
+## StreamingContainer
+
+ImageAxes implements a non-AbstractArray type [`StreamingContainer`](@ref)
+for handling streaming media or computationally-generated images.
+It provides much of the interface of AbstractArrays without the implicit promise
+of random access or efficient indexing for all axes.

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,0 +1,20 @@
+# API reference
+
+## time axes
+
+```@docs
+timeaxis
+istimeaxis
+timedim
+HasTimeAxis
+TimeAxis
+```
+
+## Streaming container
+
+```@docs
+StreamingContainer
+StreamIndexStyle
+IndexAny
+IndexIncremental
+```

--- a/src/ImageAxes.jl
+++ b/src/ImageAxes.jl
@@ -356,7 +356,19 @@ StreamIndexStyle(::Type{P}, ::typeof(f!)) = IndexIncremental()
 where `P = typeof(parent(S))`.
 """
 abstract type StreamIndexStyle end
+
+"""
+    IndexAny()
+
+Indicates that an axis supports full random-access indexing.
+"""
 struct IndexAny <: StreamIndexStyle end
+"""
+    IndexIncremental()
+
+Indicates that an axis supports only incremental indexing, i.e., from `i` to `i+1`.
+This is commonly used for the temporal axis with media streams.
+"""
 struct IndexIncremental <: StreamIndexStyle end
 
 StreamIndexStyle(::Type{A}) where {A<:AbstractArray} = IndexAny()

--- a/src/ImageAxes.jl
+++ b/src/ImageAxes.jl
@@ -21,7 +21,7 @@ export # types
     StreamIndexStyle,
     # functions
     colordim,
-    data,
+    arraydata,
     getindex!,
     istimeaxis,
     timeaxis,
@@ -163,7 +163,8 @@ ImageCore.spatialorder(img::AxisArray) = filter_space_axes(AxisArrays.axes(img),
 ImageCore.size_spatial(img::AxisArray)    = filter_space_axes(AxisArrays.axes(img), size(img))
 ImageCore.indices_spatial(img::AxisArray) = filter_space_axes(AxisArrays.axes(img), axes(img))
 
-data(img::AxisArray) = img.data
+arraydata(img::AxisArray) = img.data
+@deprecate data arraydata
 
 ### Utilities for writing "simple algorithms" safely ###
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-Unitful

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 using Colors, FixedPointNumbers, MappedArrays, Test, ImageCore
-using Compat
 import AxisArrays
 
 ambs = detect_ambiguities(ImageCore,AxisArrays,Base,Core)


### PR DESCRIPTION
Fixes #30. This also switches to Project.toml release format.