### PR TITLE
permuteddimsview -> PermutedDimsArray

### DIFF
--- a/src/ImageAxes.jl
+++ b/src/ImageAxes.jl
@@ -111,9 +111,9 @@ Base.@pure function SimpleTraits.trait(t::Type{HasTimeAxis{AA}}) where AA<:AxisA
 end
 
 # Specializations to preserve the AxisArray wrapper
-function ImageCore.permuteddimsview(A::AxisArray, perm)
+function ImageCore.PermutedDimsArray(A::AxisArray, perm)
     axs = AxisArrays.axes(A)
-    AxisArray(permuteddimsview(A.data, perm), axs[[perm...]]...)
+    AxisArray(PermutedDimsArray(A.data, perm), axs[[perm...]]...)
 end
 function ImageCore.channelview(A::AxisArray)
     Ac = channelview(A.data)

--- a/src/ImageAxes.jl
+++ b/src/ImageAxes.jl
@@ -111,7 +111,7 @@ Base.@pure function SimpleTraits.trait(t::Type{HasTimeAxis{AA}}) where AA<:AxisA
 end
 
 # Specializations to preserve the AxisArray wrapper
-function ImageCore.PermutedDimsArray(A::AxisArray, perm)
+function Base.PermutedDimsArray(A::AxisArray, perm)
     axs = AxisArrays.axes(A)
     AxisArray(PermutedDimsArray(A.data, perm), axs[[perm...]]...)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,14 +110,14 @@ end
     @test AxisArrays.axes(cv) == (Axis{:color}(1:3), Axis{:y}(1:4), Axis{:x}(1:5))
     @test spatialorder(cv) == (:y, :x)
     @test colordim(cv) == 1
-    p = permuteddimsview(cv, (2,3,1))
+    p = PermutedDimsArray(cv, (2,3,1))
     @test AxisArrays.axes(p) == (Axis{:y}(1:4), Axis{:x}(1:5), Axis{:color}(1:3))
     @test colordim(p) == 3
 end
 
 @testset "nested" begin
     A = AxisArray(rand(RGB{N0f8}, 4, 5), (:y, :x), (2, 1))
-    P = permuteddimsview(A, (2, 1))
+    P = PermutedDimsArray(A, (2, 1))
     @test @inferred(pixelspacing(P)) == (1, 2)
     M = mappedarray(identity, A)
     @test @inferred(pixelspacing(M)) == (2, 1)
@@ -125,7 +125,7 @@ end
     μm = u"μm" # global const
     tax = Axis{:time}(range(0.0s, step=0.1s, length=11))
     A = AxisArray(rand(N0f16, 4, 5, 11), (:y, :x, :time), (2μm, 1μm, 0.1s))
-    P = permuteddimsview(A, (3, 1, 2))
+    P = PermutedDimsArray(A, (3, 1, 2))
     M = mappedarray(identity, A)
     @test @inferred(pixelspacing(P)) == @inferred(pixelspacing(M)) == (2μm, 1μm)
     @test @inferred(timeaxis(P)) == @inferred(timeaxis(M)) == tax
@@ -137,7 +137,7 @@ end
     @test_throws ErrorException assert_timedim_last(P)
     assert_timedim_last(M)
     A = AxisArray(rand(N0f16, 11, 5, 4), (:time, :x, :y), (0.1s, 1μm, 2μm))
-    P = permuteddimsview(A, (3, 2, 1))
+    P = PermutedDimsArray(A, (3, 2, 1))
     M = mappedarray(identity, A)
     @test @inferred(pixelspacing(P)) == (2μm, 1μm)
     @test @inferred(pixelspacing(M)) == (1μm, 2μm)


### PR DESCRIPTION
## Before Change
On a Jupyter notebook with Julia 1.4.2, Images v0.22.4 (specifically with ImageAxes v0.6.5 and ImageMetadata v0.9.2):

```
using Images

┌ Info: Precompiling Images [916415d5-f1e6-5110-898d-aaa5f9f070e0]
└ @ Base loading.jl:1260
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/ImageAxes/ppqC3/src/ImageAxes.jl:114
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/ImageMetadata/Ss1Hl/src/ImageMetadata.jl:243
```

```
x= rand(1, 40, 40, 1)
colorview(Gray, x[1, :, :, 1])

┌ Info: Precompiling PNGFiles [f57f5aa1-a3ce-4bc8-8ab9-96f992907883]
└ @ Base loading.jl:1260
┌ Info: Precompiling ImageMagick [6218d12a-5da1-5696-b52f-db25d2ecc6d1]
└ @ Base loading.jl:1260

WARNING: importing deprecated binding ImageCore.permuteddimsview into ImageAxes.
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: importing deprecated binding ImageCore.permuteddimsview into ImageMetadata.
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
```

## After Change
Combined with https://github.com/JuliaImages/ImageMetadata.jl/pull/69
```
using Images

┌ Info: Precompiling Images [916415d5-f1e6-5110-898d-aaa5f9f070e0]
└ @ Base loading.jl:1260

x= rand(1, 40, 40, 1)
colorview(Gray, x[1, :, :, 1])
```