### PR TITLE
extend `OffsetArrays.centered` for `AxisArray`/`Axis`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,14 +5,12 @@ version = "0.6.9"
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
-OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
 
 [compat]
 AxisArrays = "0.3, 0.4"
 ImageCore = "0.8.1, 0.9"
-OffsetArrays = "1.9"
 Reexport = "0.2, 1.0"
 SimpleTraits = "0.8, 0.9"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,14 @@ version = "0.6.9"
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
 
 [compat]
 AxisArrays = "0.3, 0.4"
 ImageCore = "0.8.1, 0.9"
+OffsetArrays = "1.9"
 Reexport = "0.2, 1.0"
 SimpleTraits = "0.8, 0.9"
 julia = "1"

--- a/src/ImageAxes.jl
+++ b/src/ImageAxes.jl
@@ -11,7 +11,7 @@ export AxisArray, Axis, axisnames, axisvalues, axisdim, atindex, atvalue, collap
 
 @reexport using ImageCore
 using ImageCore.MappedArrays
-using OffsetArrays
+using ImageCore.OffsetArrays
 
 
 export # types

--- a/src/ImageAxes.jl
+++ b/src/ImageAxes.jl
@@ -11,6 +11,7 @@ export AxisArray, Axis, axisnames, axisvalues, axisdim, atindex, atvalue, collap
 
 @reexport using ImageCore
 using ImageCore.MappedArrays
+using OffsetArrays
 
 
 export # types
@@ -439,5 +440,8 @@ function AxisArrays._summary(io, A::AxisArray{T,N}) where {T<:Union{Fractional,C
     end
     println(io, ",$N,...} with axes:")
 end
+
+# glue codes
+include("offsetarrays.jl")
 
 end # module

--- a/src/offsetarrays.jl
+++ b/src/offsetarrays.jl
@@ -1,5 +1,7 @@
-# Requires OffsetArrays v1.9
-# https://github.com/JuliaArrays/OffsetArrays.jl/pull/242
-# Originally from ImageFiltering https://github.com/JuliaImages/ImageFiltering.jl/pull/214
-OffsetArrays.centered(ax::Axis{name}) where name = Axis{name}(OffsetArrays.centered(ax.val))
-OffsetArrays.centered(a::AxisArray) = AxisArray(OffsetArrays.centered(a.data), OffsetArrays.centered.(AxisArrays.axes(a)))
+if isdefined(OffsetArrays, :centered)
+    # Requires OffsetArrays v1.9
+    # https://github.com/JuliaArrays/OffsetArrays.jl/pull/242
+    # Originally from ImageFiltering https://github.com/JuliaImages/ImageFiltering.jl/pull/214
+    OffsetArrays.centered(ax::Axis{name}) where name = Axis{name}(OffsetArrays.centered(ax.val))
+    OffsetArrays.centered(a::AxisArray) = AxisArray(OffsetArrays.centered(a.data), OffsetArrays.centered.(AxisArrays.axes(a)))
+end

--- a/src/offsetarrays.jl
+++ b/src/offsetarrays.jl
@@ -1,0 +1,5 @@
+# Requires OffsetArrays v1.9
+# https://github.com/JuliaArrays/OffsetArrays.jl/pull/242
+# Originally from ImageFiltering https://github.com/JuliaImages/ImageFiltering.jl/pull/214
+OffsetArrays.centered(ax::Axis{name}) where name = Axis{name}(OffsetArrays.centered(ax.val))
+OffsetArrays.centered(a::AxisArray) = AxisArray(OffsetArrays.centered(a.data), OffsetArrays.centered.(AxisArrays.axes(a)))

--- a/test/offsetarrays.jl
+++ b/test/offsetarrays.jl
@@ -1,19 +1,21 @@
 @testset "centered" begin
-    check_range(r, f, l) = (@test first(r) == f; @test last(r) == l)
-    check_range_axes(r, f, l) = check_range(Base.axes(r)[1], f, l)
+    if isdefined(OffsetArrays, :centered) # OffsetArrays v1.9
+        check_range(r, f, l) = (@test first(r) == f; @test last(r) == l)
+        check_range_axes(r, f, l) = check_range(Base.axes(r)[1], f, l)
 
-    check_range(Base.axes(OffsetArrays.centered(1:3))[1], -1, 1)
-    a = AxisArray(rand(3, 3), Axis{:y}(0.1:0.1:0.3), Axis{:x}(1:3))
+        check_range(Base.axes(OffsetArrays.centered(1:3))[1], -1, 1)
+        a = AxisArray(rand(3, 3), Axis{:y}(0.1:0.1:0.3), Axis{:x}(1:3))
 
-    ca = OffsetArrays.centered(a)
-    axs = Base.axes(ca)
-    check_range(axs[1], -1, 1)
-    check_range(axs[2], -1, 1)
-    @test ca[OffsetArrays.center(ca)...] == a[OffsetArrays.center(a)...]
+        ca = OffsetArrays.centered(a)
+        axs = Base.axes(ca)
+        check_range(axs[1], -1, 1)
+        check_range(axs[2], -1, 1)
+        @test ca[OffsetArrays.center(ca)...] == a[OffsetArrays.center(a)...]
 
-    axs = AxisArrays.axes(ca)
-    check_range(axs[1].val, 0.1, 0.3)
-    check_range(axs[2].val, 1, 3)
-    check_range_axes(axs[1].val, -1, 1)
-    check_range_axes(axs[1].val, -1, 1)
+        axs = AxisArrays.axes(ca)
+        check_range(axs[1].val, 0.1, 0.3)
+        check_range(axs[2].val, 1, 3)
+        check_range_axes(axs[1].val, -1, 1)
+        check_range_axes(axs[1].val, -1, 1)
+    end
 end

--- a/test/offsetarrays.jl
+++ b/test/offsetarrays.jl
@@ -1,0 +1,19 @@
+@testset "centered" begin
+    check_range(r, f, l) = (@test first(r) == f; @test last(r) == l)
+    check_range_axes(r, f, l) = check_range(Base.axes(r)[1], f, l)
+
+    check_range(Base.axes(OffsetArrays.centered(1:3))[1], -1, 1)
+    a = AxisArray(rand(3, 3), Axis{:y}(0.1:0.1:0.3), Axis{:x}(1:3))
+
+    ca = OffsetArrays.centered(a)
+    axs = Base.axes(ca)
+    check_range(axs[1], -1, 1)
+    check_range(axs[2], -1, 1)
+    @test ca[OffsetArrays.center(ca)...] == a[OffsetArrays.center(a)...]
+
+    axs = AxisArrays.axes(ca)
+    check_range(axs[1].val, 0.1, 0.3)
+    check_range(axs[2].val, 1, 3)
+    check_range_axes(axs[1].val, -1, 1)
+    check_range_axes(axs[1].val, -1, 1)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Test, ImageCore
 using ImageCore.MappedArrays
+using ImageCore.OffsetArrays
 import AxisArrays
-using OffsetArrays
 
 ambs = detect_ambiguities(ImageCore,AxisArrays,Base,Core)
 using ImageAxes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test, ImageCore
 using ImageCore.MappedArrays
 import AxisArrays
+using OffsetArrays
 
 ambs = detect_ambiguities(ImageCore,AxisArrays,Base,Core)
 using ImageAxes
@@ -230,6 +231,10 @@ end
     # internal
     @test ImageAxes.streamingaxisnames(S) == (:time,)
     @test ImageAxes.filter_streamed((1,2), S) == (2,)
+end
+
+@testset "OffsetArrays" begin
+    include("offsetarrays.jl")
 end
 
 nothing


### PR DESCRIPTION
Moved from https://github.com/JuliaArrays/AxisArrays.jl/pull/196

Because OffsetArrays is already included as a part of ImageCore, adding this adds no extra latencies.