### PR TITLE
port `restrict` from Images

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,20 +4,23 @@ version = "0.6.9"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
+ImageBase = "c817782e-172a-44cc-b673-b171935fbb9e"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
 
 [compat]
 AxisArrays = "0.3, 0.4"
+ImageBase = "0.1.1"
 ImageCore = "0.8.1, 0.9"
 Reexport = "0.2, 1.0"
 SimpleTraits = "0.8, 0.9"
 julia = "1"
 
 [extras]
+ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Unitful", "Test"]
+test = ["ColorVectorSpace", "Unitful", "Test"]

--- a/src/ImageAxes.jl
+++ b/src/ImageAxes.jl
@@ -12,6 +12,7 @@ export AxisArray, Axis, axisnames, axisvalues, axisdim, atindex, atvalue, collap
 @reexport using ImageCore
 using ImageCore.MappedArrays
 using ImageCore.OffsetArrays
+import ImageBase: restrict
 
 
 export # types
@@ -443,5 +444,6 @@ end
 
 # glue codes
 include("offsetarrays.jl")
+include("restrict.jl")
 
 end # module

--- a/src/restrict.jl
+++ b/src/restrict.jl
@@ -1,0 +1,35 @@
+# Originally from Images.jl
+restrict(img::AxisArray, ::Tuple{}) = img
+
+function restrict(img::AxisArray, region::Dims)
+    inregiont = ntuple(i->in(i, region), ndims(img))
+    rdata = restrict(img.data, region)
+    AxisArray(rdata, map(modax, AxisArrays.axes(img), axes(rdata), inregiont))
+end
+
+function restrict(img::AxisArray, ::Type{Ax}) where Ax
+    dim = axisdim(img, Ax)
+    A = restrict(img.data, dim)
+    AxisArray(A, replace_axis(modax(img[Ax], axes(A)[dim]), AxisArrays.axes(img)))
+end
+
+replace_axis(newax, axs) = _replace_axis(newax, axnametype(newax), axs...)
+@inline _replace_axis(newax, ::Type{Ax}, ax::Ax, axs...) where {Ax} = (newax, _replace_axis(newax, Ax, axs...)...)
+@inline _replace_axis(newax, ::Type{Ax}, ax, axs...) where {Ax} = (ax, _replace_axis(newax, Ax, axs...)...)
+_replace_axis(newax, ::Type{Ax}) where {Ax} = ()
+
+axnametype(ax::Axis{name}) where {name} = Axis{name}
+
+ofaxes(::Base.OneTo, r) = r
+ofaxes(axs::Any, r) = OffsetArray(r, axs)
+
+function modax(ax, Aax)
+    v = ax.val
+    if iseven(length(v))
+        return ax(ofaxes(Aax, range(first(v)-step(v)/2, stop=last(v)+step(v)/2, length=length(v)÷2 + 1)))
+    else
+        return ax(ofaxes(Aax, range(first(v)/1, stop=last(v)/1, length=length(v)÷2 + 1)))
+    end
+end
+
+modax(ax, Aax, inregion::Bool) = inregion ? modax(ax, Aax) : ax

--- a/test/offsetarrays.jl
+++ b/test/offsetarrays.jl
@@ -1,21 +1,23 @@
-@testset "centered" begin
-    if isdefined(OffsetArrays, :centered) # OffsetArrays v1.9
-        check_range(r, f, l) = (@test first(r) == f; @test last(r) == l)
-        check_range_axes(r, f, l) = check_range(Base.axes(r)[1], f, l)
+@testset "OffsetArrays" begin
+    @testset "centered" begin
+        if isdefined(OffsetArrays, :centered) # OffsetArrays v1.9
+            check_range(r, f, l) = (@test first(r) == f; @test last(r) == l)
+            check_range_axes(r, f, l) = check_range(Base.axes(r)[1], f, l)
 
-        check_range(Base.axes(OffsetArrays.centered(1:3))[1], -1, 1)
-        a = AxisArray(rand(3, 3), Axis{:y}(0.1:0.1:0.3), Axis{:x}(1:3))
+            check_range(Base.axes(OffsetArrays.centered(1:3))[1], -1, 1)
+            a = AxisArray(rand(3, 3), Axis{:y}(0.1:0.1:0.3), Axis{:x}(1:3))
 
-        ca = OffsetArrays.centered(a)
-        axs = Base.axes(ca)
-        check_range(axs[1], -1, 1)
-        check_range(axs[2], -1, 1)
-        @test ca[OffsetArrays.center(ca)...] == a[OffsetArrays.center(a)...]
+            ca = OffsetArrays.centered(a)
+            axs = Base.axes(ca)
+            check_range(axs[1], -1, 1)
+            check_range(axs[2], -1, 1)
+            @test ca[OffsetArrays.center(ca)...] == a[OffsetArrays.center(a)...]
 
-        axs = AxisArrays.axes(ca)
-        check_range(axs[1].val, 0.1, 0.3)
-        check_range(axs[2].val, 1, 3)
-        check_range_axes(axs[1].val, -1, 1)
-        check_range_axes(axs[1].val, -1, 1)
+            axs = AxisArrays.axes(ca)
+            check_range(axs[1].val, 0.1, 0.3)
+            check_range(axs[2].val, 1, 3)
+            check_range_axes(axs[1].val, -1, 1)
+            check_range_axes(axs[1].val, -1, 1)
+        end
     end
 end

--- a/test/restrict.jl
+++ b/test/restrict.jl
@@ -1,0 +1,28 @@
+@testset "restrict" begin
+    imgcol = rand(RGB{Float64}, 5, 6)
+    imgcolax = AxisArray(imgcol, :y, :x)
+    imgr = restrict(imgcolax, (1,2))
+    @test pixelspacing(imgr) == (2,2)
+    @test pixelspacing(imgcolax) == (1,1)  # issue https://github.com/JuliaImages/Images.jl/issues/347
+
+    imgr = @inferred(restrict(imgcolax, Axis{:y}))
+    @test pixelspacing(imgr) == (2, 1)
+    imgr = @inferred(restrict(imgcolax, Axis{:x}))
+    @test pixelspacing(imgr) == (1, 2)
+
+    @testset "OffsetArray" begin
+        A = ones(4, 5)
+        Ao = OffsetArray(A, 0:3, -2:2)
+        Aor = restrict(Ao)
+        @test axes(Aor) == axes(OffsetArray(restrict(A), 0:2, -1:1))
+
+        # restricting AxisArrays with offset axes
+        AA = AxisArray(Ao, Axis{:y}(0:3), Axis{:x}(-2:2))
+        @test axes(AA) === axes(Ao)
+        AAr = restrict(AA)
+        axs = axisvalues(AAr)
+        @test axes(axs[1])[1] == axes(Aor)[1]
+        @test axes(axs[2])[1] == axes(Aor)[2]
+        AAA = AxisArray(Aor, axs)  # just test that it's constructable (another way of enforcing agreement)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ using Test, ImageCore
 using ImageCore.MappedArrays
 using ImageCore.OffsetArrays
 import AxisArrays
+using ImageBase: restrict
+using ColorVectorSpace
 
 ambs = detect_ambiguities(ImageCore,AxisArrays,Base,Core)
 using ImageAxes
@@ -233,8 +235,8 @@ end
     @test ImageAxes.filter_streamed((1,2), S) == (2,)
 end
 
-@testset "OffsetArrays" begin
-    include("offsetarrays.jl")
-end
+# glue codes
+include("offsetarrays.jl")
+include("restrict.jl")
 
 nothing


### PR DESCRIPTION
With `restrict` now moved to ImageBase, it's possible to port [the glue codes from Images.jl](https://github.com/JuliaImages/Images.jl/blob/e14a49f3057af969fd026cfd86ab8960d7838ecf/src/algorithms.jl#L436-L478) to this package and ImageMetadata.